### PR TITLE
🔒 Security: 매직 바이트 검증을 통한 비정상 파일 업로드 차단 확인

### DIFF
--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -34,6 +34,9 @@ public class ReceiptService {
   private final GoogleOcrClient googleOcrClient;
   private final GeminiService geminiService;
 
+  private final String uploadDir =
+      System.getProperty("user.home") + File.separator + "remate_uploads" + File.separator;
+
   @Transactional
   public Receipt uploadAndProcess(
       String idempotencyKey, MultipartFile file, Long workspaceId, Long userId) {
@@ -118,9 +121,6 @@ public class ReceiptService {
             .build());
   }
 
-  private final String uploadDir =
-      System.getProperty("user.home") + File.separator + "remate_uploads" + File.separator;
-
   private String saveFileToLocal(MultipartFile file) {
     try {
       File dir = new File(uploadDir);
@@ -145,13 +145,30 @@ public class ReceiptService {
   }
 
   private void validateFile(MultipartFile file) {
-    String contentType = file.getContentType();
-    if (contentType == null
-        || (!contentType.equals("image/jpeg")
-            && !contentType.equals("image/png")
-            && !contentType.equals("application/pdf"))) {
-      throw new RuntimeException("FILE_TYPE_NOT_ALLOWED");
+    try {
+      byte[] header = new byte[8];
+      if (file.getInputStream().read(header) < 4) {
+        throw new RuntimeException("FILE_TOO_SMALL");
+      }
+
+      if (isJpeg(header) || isPng(header)) {
+        return;
+      }
+      throw new RuntimeException("INVALID_FILE_SIGNATURE");
+    } catch (IOException e) {
+      throw new RuntimeException("FILE_READ_ERROR");
     }
+  }
+
+  private boolean isJpeg(byte[] h) {
+    return (h[0] & 0xFF) == 0xFF && (h[1] & 0xFF) == 0xD8 && (h[2] & 0xFF) == 0xFF;
+  }
+
+  private boolean isPng(byte[] h) {
+    return (h[0] & 0xFF) == 0x89
+        && (h[1] & 0xFF) == 0x50
+        && (h[2] & 0xFF) == 0x4E
+        && (h[3] & 0xFF) == 0x47;
   }
 
   public List<Receipt> getAllReceipts() {


### PR DESCRIPTION
## 개요
업로드 보안 강화를 위해 기존의 단순 확장자 체크 방식을 넘어, 파일의 실제 헤더(Magic Byte)를 검증하는 로직을 구현했습니다.

## 작업 내용
파일 검증 고도화 (3단계): 확장자 사칭 공격을 방지하기 위해 파일 바이너리 헤더를 직접 읽어 진짜 JPG, PNG 파일인지 검증하는 로직을 ReceiptService에 추가했습니다.

허용 확장자 제한: 프로젝트 요구사항에 맞춰 JPG, JPEG, PNG 파일만 허용하도록 범위를 설정했습니다.

예외 처리: 비정상 파일 감지 시 INVALID_FILE_SIGNATURE 예외를 던져 보안 안정성을 확보했습니다.

## 테스트 결과
정상 케이스: 순수 이미지 파일(.jpg, .jpeg, .png) 업로드 시 정상적으로 분석 및 저장됨을 확인했습니다.

차단 케이스: 텍스트 파일의 확장자만 변경하여 업로드 시 백엔드 로그에서 RuntimeException: INVALID_FILE_SIGNATURE 에러와 함께 차단됨을 검증했습니다.

## 관련 로드맵 및 이슈
로드맵 3단계: 업로드 보안 강화 항목 완료.

다음 작업: 2순위 5번 '조회 스코프 + 404 처리' 진행 예정입니다.