### PR TITLE
✨ Feat: 야간 태그 버그 수정 및 UI 가로 너비 확장

### DIFF
--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -27,7 +27,9 @@ public class Receipt {
 
   private int totalAmount;
 
-  private boolean nightTime;
+  @Builder.Default
+  @Column(name = "night_time", columnDefinition = "TINYINT(1)")
+  private boolean nightTime = false;
 
   @Column(unique = true)
   private String idempotencyKey;
@@ -75,6 +77,7 @@ public class Receipt {
     }
     if (tradeAt != null) {
       this.tradeAt = tradeAt;
+      this.nightTime = (tradeAt.getHour() >= 23 || tradeAt.getHour() < 6);
     }
     this.status = ReceiptStatus.APPROVED;
   }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -133,6 +133,12 @@ public class ReceiptService {
     int totalAmount = aiResult.path("totalAmount").asInt(0);
     String tradeAtStr = aiResult.path("tradeAt").asText();
 
+    log.info(
+        "AI 파싱 결과 - storeName: {}, totalAmount: {}, tradeAtStr: {}",
+        storeName,
+        totalAmount,
+        tradeAtStr);
+
     ReceiptStatus finalStatus =
         (aiResult.has("storeName") && !storeName.equals("알 수 없는 상호"))
             ? ReceiptStatus.WAITING
@@ -147,7 +153,9 @@ public class ReceiptService {
 
     boolean isNightTime = (tradeAt.getHour() >= 23 || tradeAt.getHour() < 6);
 
-    return receiptRepository.save(
+    log.info("야간 여부 계산 - tradeAt hour: {}, isNightTime: {}", tradeAt.getHour(), isNightTime);
+
+    Receipt receipt =
         Receipt.builder()
             .idempotencyKey(key)
             .fileHash(fileHash)
@@ -160,7 +168,9 @@ public class ReceiptService {
             .nightTime(isNightTime)
             .rawText(fullText)
             .filePath(filePath)
-            .build());
+            .build();
+
+    return receiptRepository.save(receipt);
   }
 
   private String saveFileToLocal(MultipartFile file) {

--- a/src/main/resources/static/upload.html
+++ b/src/main/resources/static/upload.html
@@ -6,7 +6,7 @@
     <style>
         :root { --primary:#3b82f6; --bg:#f8fafc; --card:#ffffff; --text:#1e293b; }
         body{ font-family:'Pretendard',sans-serif; background:var(--bg); margin:0; padding:40px 20px; display:flex; flex-direction:column; align-items:center; color:var(--text); }
-        .card{ background:var(--card); padding:32px; border-radius:24px; box-shadow:0 10px 25px rgba(0,0,0,0.05); width:100%; max-width:980px; margin-bottom:24px; }
+        .card{ background:var(--card); padding:32px; border-radius:24px; box-shadow:0 10px 25px rgba(0,0,0,0.05); width:100%; max-width:1200px; margin-bottom:24px; }
         h2,h3{ margin-top:0; font-weight:700; letter-spacing:-0.5px; }
 
         .upload-zone{ border:2px dashed #e2e8f0; padding:40px; border-radius:16px; margin-bottom:16px; transition:.3s; cursor:pointer; text-align:center; }
@@ -174,6 +174,10 @@
                 const dis = isProcessable ? '' : 'disabled';
                 const tradeAt = r.tradeAt ? r.tradeAt.replace('T', ' ').substring(0, 16) : '-';
 
+                // 1. 야간 태그 변수 생성 (이 부분 추가!)
+                const nightBadge = r.nightTime
+                    ? '<span style="background:#1e293b; color:#fff; padding:2px 6px; border-radius:4px; font-size:0.65rem; margin-left:4px;">🌙 야간</span>'
+                    : '';
 
                 const reasonAttr = (r.status === 'REJECTED' && r.rejectionReason)
                     ? `data-reason="${escapeHtml(r.rejectionReason)}"`
@@ -185,7 +189,10 @@
             <td style="text-align:left"><strong>${escapeHtml(r.storeName)}</strong></td>
             <td>${escapeHtml(tradeAt)}</td>
             <td style="font-weight:700">${(r.totalAmount || 0).toLocaleString()}원</td>
-            <td><span class="status-badge ${r.status}" ${reasonAttr}>${r.status}</span></td>
+            <td>
+                <span class="status-badge ${r.status}" ${reasonAttr}>${r.status}</span>
+                ${nightBadge}
+            </td>
             <td>
               <button class="action-btn" ${dis} data-action="edit" data-id="${r.id}">✏️ 수정</button>
               <button class="action-btn" data-action="history" data-id="${r.id}">📜 이력</button>


### PR DESCRIPTION
## 1. 개요 (Overview)
영수증 정보 수정 시 야간 판별 데이터가 누락되거나 DB에 정상적으로 표시되지 않던 문제를 해결하고, 사용자 편의를 위해 리스트 UI를 개선했습니다.

## 2. 주요 변경 사항 (Key Changes)
엔티티 로직 보강: Receipt 엔티티의 updateInfo 메서드에서 tradeAt 변경 시 nightTime 여부를 자동으로 재계산하도록 가드 로직을 추가했습니다.

DB 데이터 타입 최적화: MariaDB의 night_time 컬럼 타입을 BIT(1)에서 TINYINT(1)로 동기화하여 데이터 조회 시 가독성을 확보했습니다.

리스트 UI 시각화:

분석된 영수증 내역에 🌙 야간 태그를 추가하여 한눈에 지출 성격을 파악할 수 있게 개선했습니다.

카드 컴포넌트의 가로 너비를 확장하여 많은 데이터가 포함된 테이블의 가독성을 높였습니다.

## 3. 작업 결과 (Screenshots)
백엔드: 로그 확인 결과 tradeAt 파싱 시 isNightTime: true 정상 확인.

DB: SELECT 쿼리 시 night_time 컬럼에 1이 정상적으로 기록됨을 확인.

프론트엔드: 첨부 이미지와 같이 상태 배지 옆에 야간 아이콘이 정상 노출됨.

## 4. 리뷰어 가이드 (Reviewer Guide)
PR을 로컬 환경에서 실행하신 후, 야간 시간대(23:00 ~ 06:00) 영수증을 업로드하거나 기존 영수증을 해당 시간으로 수정하여 태그가 잘 뜨는지 확인 부탁드립니다.

Spotless: spotlessApply를 통해 코드 스타일 통일을 완료했습니다.