### PR TITLE
✨ Feat: 시스템 실패 상태 및 에러 코드 규격화 반영

### DIFF
--- a/src/main/java/com/example/backend/domain/receipt/SystemErrorCode.java
+++ b/src/main/java/com/example/backend/domain/receipt/SystemErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.backend.domain.receipt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SystemErrorCode {
+  INVALID_FILE_FORMAT("지원하지 않는 파일 형식입니다."),
+  OCR_CONNECTION_FAILURE("OCR 서버와의 통신에 실패했습니다."),
+  OCR_RESPONSE_TIMEOUT("OCR 분석 시간이 초과되었습니다."),
+
+  AI_PARSING_ERROR("추출된 데이터를 구조화하는 데 실패했습니다."),
+  MANDATORY_DATA_MISSING("필수 데이터(금액, 가맹점 등)를 찾을 수 없습니다."),
+  LOW_CONFIDENCE_SCORE("분석 결과의 신뢰도가 너무 낮습니다."),
+
+  INTERNAL_SERVER_ERROR("서버 내부 로직 처리 중 오류가 발생했습니다."),
+  UNKNOWN_ERROR("정의되지 않은 시스템 오류가 발생했습니다.");
+
+  private final String message;
+}

--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -1,6 +1,7 @@
 package com.example.backend.entity;
 
 import com.example.backend.domain.receipt.ReceiptStatus;
+import com.example.backend.domain.receipt.SystemErrorCode;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
@@ -20,6 +21,9 @@ public class Receipt {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private ReceiptStatus status;
+
+  @Enumerated(EnumType.STRING)
+  private SystemErrorCode systemErrorCode;
 
   private String storeName;
 
@@ -72,6 +76,11 @@ public class Receipt {
     }
   }
 
+  public void updateSystemError(SystemErrorCode errorCode) {
+    this.status = ReceiptStatus.FAILED_SYSTEM;
+    this.systemErrorCode = errorCode;
+  }
+
   public void updateInfo(Integer totalAmount, String storeName, LocalDateTime tradeAt) {
     if (this.status == ReceiptStatus.APPROVED) {
       throw new IllegalStateException("이미 승인된 영수증은 수정할 수 없습니다.");
@@ -88,5 +97,6 @@ public class Receipt {
       this.nightTime = (tradeAt.getHour() >= 23 || tradeAt.getHour() < 6);
     }
     this.status = ReceiptStatus.APPROVED;
+    this.systemErrorCode = null;
   }
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -57,6 +57,8 @@ public class ReceiptService {
                           () -> {
                             try {
                               String savedFileName = saveFileToLocal(file);
+                              //                              if (true) throw new IOException("테스트용
+                              // OCR 연결 실패");
                               JsonNode ocrJson = googleOcrClient.recognize(fileBytes);
                               return parseAndSave(
                                   idempotencyKey,
@@ -67,7 +69,8 @@ public class ReceiptService {
                                   savedFileName);
                             } catch (Exception e) {
                               log.error("OCR 분석 에러", e);
-                              throw new RuntimeException("OCR_PROCESSING_FAILED");
+                              return saveFailedReceipt(
+                                  idempotencyKey, fileHash, workspaceId, userId, null, e);
                             }
                           }));
     } catch (Exception e) {
@@ -254,5 +257,30 @@ public class ReceiptService {
             })
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
+  }
+
+  private Receipt saveFailedReceipt(
+      String key, String hash, Long workspaceId, Long userId, String path, Exception e) {
+    com.example.backend.domain.receipt.SystemErrorCode errorCode =
+        com.example.backend.domain.receipt.SystemErrorCode.UNKNOWN_ERROR;
+
+    if (e instanceof IOException) {
+      errorCode = com.example.backend.domain.receipt.SystemErrorCode.OCR_CONNECTION_FAILURE;
+    } else if (e.getMessage() != null && e.getMessage().contains("parse")) {
+      errorCode = com.example.backend.domain.receipt.SystemErrorCode.AI_PARSING_ERROR;
+    }
+
+    Receipt receipt =
+        Receipt.builder()
+            .idempotencyKey(key)
+            .fileHash(hash)
+            .workspaceId(workspaceId)
+            .userId(userId)
+            .status(ReceiptStatus.FAILED_SYSTEM)
+            .systemErrorCode(errorCode)
+            .filePath(path)
+            .build();
+
+    return receiptRepository.save(receipt);
   }
 }


### PR DESCRIPTION
## 1. 작업 개요
파편화되어 있던 영수증 분석 실패 상태를 FAILED_SYSTEM으로 통합하고, 구체적인 원인을 기록할 수 있는 규격을 마련했습니다.

## 2. 주요 변경 사항
SystemErrorCode Enum 신설: OCR_CONNECTION_FAILURE, AI_PARSING_ERROR 등 기술적 실패 원인 정의

Receipt 엔티티 수정: systemErrorCode 필드 추가 및 상태 변경 로직(updateSystemError) 구현

ReceiptStatus 정리: 기존 FAILED_OCR, FAILED_ML을 삭제하고 FAILED_SYSTEM으로 단일화

서비스 로직 반영: 분석 예외 발생 시 해당 에러 코드를 포함하여 FAILED_SYSTEM 상태로 DB에 저장되도록 개선

## 3. 테스트 결과
정상 시: WAITING 또는 NEED_MANUAL 상태로 정상 저장 확인

실패 시: 의도적 예외 발생 테스트를 통해 DB에 FAILED_SYSTEM 상태와 OCR_CONNECTION_FAILURE 코드가 정확히 기록됨을 확인 
<img width="1154" height="211" alt="image" src="https://github.com/user-attachments/assets/aa41706d-7a0f-4f6a-a3bd-d6eb8d723273" />
