### PR TITLE
✨ Feat: 초기 상태 ANALYZING 선저장 구조 및 상태 전이 가드 구현

### DIFF
--- a/src/main/java/com/example/backend/domain/receipt/ReceiptStatus.java
+++ b/src/main/java/com/example/backend/domain/receipt/ReceiptStatus.java
@@ -1,5 +1,8 @@
 package com.example.backend.domain.receipt;
 
+import java.util.List;
+import java.util.Map;
+
 public enum ReceiptStatus {
   UPLOADED,
   ANALYZING,
@@ -8,5 +11,20 @@ public enum ReceiptStatus {
   APPROVED,
   REJECTED,
   FAILED_SYSTEM,
-  EXPIRED
+  EXPIRED;
+
+  private static final Map<ReceiptStatus, List<ReceiptStatus>> TRANSITION_TABLE =
+      Map.of(
+          ANALYZING, List.of(WAITING, NEED_MANUAL, FAILED_SYSTEM),
+          WAITING, List.of(APPROVED, REJECTED, EXPIRED),
+          NEED_MANUAL, List.of(WAITING, APPROVED, REJECTED),
+          REJECTED, List.of(WAITING),
+          APPROVED, List.of());
+
+  public boolean canTransitionTo(ReceiptStatus nextStatus) {
+    if (this == nextStatus) return true;
+    List<String> allowed =
+        TRANSITION_TABLE.getOrDefault(this, List.of()).stream().map(Enum::name).toList();
+    return TRANSITION_TABLE.getOrDefault(this, List.of()).contains(nextStatus);
+  }
 }

--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -78,20 +78,41 @@ public class Receipt {
     }
   }
 
+  public void updateAfterAnalysis(
+      String storeName,
+      int totalAmount,
+      LocalDateTime tradeAt,
+      String rawText,
+      ReceiptStatus status,
+      java.util.List<String> tags,
+      boolean nightTime) {
+    this.storeName = storeName;
+    this.totalAmount = totalAmount;
+    this.tradeAt = tradeAt;
+    this.rawText = rawText;
+    this.status = status;
+    this.tags.clear();
+    if (tags != null) this.tags.addAll(tags);
+    this.nightTime = nightTime;
+  }
+
+  public void markAsFailed(SystemErrorCode errorCode) {
+    this.status = ReceiptStatus.FAILED_SYSTEM;
+    this.systemErrorCode = errorCode;
+  }
+
   public void updateStatus(ReceiptStatus status, String reason) {
     if (this.status == ReceiptStatus.APPROVED && status != ReceiptStatus.APPROVED) {
       throw new IllegalStateException("이미 승인된 영수증의 상태를 변경할 수 없습니다.");
+    }
+    if (!this.status.canTransitionTo(status)) {
+      throw new IllegalStateException("INVALID_STATE_TRANSITION");
     }
 
     this.status = status;
     if (status == ReceiptStatus.REJECTED) {
       this.rejectionReason = reason;
     }
-  }
-
-  public void updateSystemError(SystemErrorCode errorCode) {
-    this.status = ReceiptStatus.FAILED_SYSTEM;
-    this.systemErrorCode = errorCode;
   }
 
   public void updateInfo(Integer totalAmount, String storeName, LocalDateTime tradeAt) {
@@ -109,15 +130,17 @@ public class Receipt {
       this.tradeAt = tradeAt;
       this.nightTime = (tradeAt.getHour() >= 23 || tradeAt.getHour() < 6);
     }
-    this.status = ReceiptStatus.APPROVED;
     this.systemErrorCode = null;
   }
 
+  public void updateSystemError(SystemErrorCode errorCode) {
+    this.status = ReceiptStatus.FAILED_SYSTEM;
+    this.systemErrorCode = errorCode;
+  }
+
   public void resubmit() {
-    if (this.status != ReceiptStatus.REJECTED) {
-      throw new IllegalStateException("반려된 상태의 영수증만 재제출이 가능합니다.");
-    }
-    this.status = ReceiptStatus.WAITING;
+
+    updateStatus(ReceiptStatus.WAITING, null);
     this.rejectionReason = null;
   }
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -59,25 +59,89 @@ public class ReceiptService {
                       .findByIdempotencyKey(idempotencyKey)
                       .orElseGet(
                           () -> {
+                            String savedFileName = null;
+                            Receipt receipt = null;
                             try {
-                              String savedFileName = saveFileToLocal(file);
+                              savedFileName = saveFileToLocal(file);
+
+                              receipt =
+                                  receiptRepository.save(
+                                      Receipt.builder()
+                                          .idempotencyKey(idempotencyKey)
+                                          .fileHash(fileHash)
+                                          .workspaceId(workspaceId)
+                                          .userId(userId)
+                                          .status(ReceiptStatus.ANALYZING)
+                                          .filePath(savedFileName)
+                                          .build());
+                              log.info(
+                                  "=== [검증 1] DB 선저장 완료: ID={}, Status={}",
+                                  receipt.getId(),
+                                  receipt.getStatus());
+
                               JsonNode ocrJson = googleOcrClient.recognize(fileBytes);
-                              return parseAndSave(
-                                  idempotencyKey,
-                                  fileHash,
-                                  ocrJson,
-                                  workspaceId,
-                                  userId,
-                                  savedFileName);
+                              log.info("=== [검증 2] OCR 분석 시작 (ID: {})", receipt.getId());
+                              return processOcrResult(receipt, ocrJson);
+
                             } catch (Exception e) {
                               log.error("OCR 분석 에러", e);
+                              if (receipt != null) {
+                                return markAsFailed(receipt, e);
+                              }
                               return saveFailedReceipt(
-                                  idempotencyKey, fileHash, workspaceId, userId, null, e);
+                                  idempotencyKey, fileHash, workspaceId, userId, savedFileName, e);
                             }
                           }));
     } catch (Exception e) {
       throw new RuntimeException("FILE_PROCESSING_FAILED", e);
     }
+  }
+
+  private Receipt processOcrResult(Receipt receipt, JsonNode ocrJson) {
+    JsonNode textAnnotations = ocrJson.path("responses").get(0).path("textAnnotations");
+    String fullText =
+        textAnnotations.isMissingNode() ? "" : textAnnotations.get(0).path("description").asText();
+
+    JsonNode aiResult = geminiService.getParsedReceipt(fullText);
+
+    String storeName = aiResult.path("storeName").asText("알 수 없는 상호");
+    int totalAmount = aiResult.path("totalAmount").asInt(0);
+    String tradeAtStr = aiResult.path("tradeAt").asText();
+
+    ReceiptStatus nextStatus =
+        (aiResult.has("storeName") && !storeName.equals("알 수 없는 상호"))
+            ? ReceiptStatus.WAITING
+            : ReceiptStatus.NEED_MANUAL;
+
+    LocalDateTime tradeAt;
+    try {
+      tradeAt = LocalDateTime.parse(tradeAtStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    } catch (Exception e) {
+      tradeAt = LocalDateTime.now();
+    }
+
+    List<String> derivedTags = tagService.deriveTags(Receipt.builder().tradeAt(tradeAt).build());
+
+    receipt.updateAfterAnalysis(
+        storeName,
+        totalAmount,
+        tradeAt,
+        fullText,
+        nextStatus,
+        derivedTags,
+        derivedTags.contains("🌙 야간"));
+
+    return receipt;
+  }
+
+  private Receipt markAsFailed(Receipt receipt, Exception e) {
+    SystemErrorCode errorCode = SystemErrorCode.UNKNOWN_ERROR;
+    if (e instanceof IOException) errorCode = SystemErrorCode.OCR_CONNECTION_FAILURE;
+    else if (e.getMessage() != null && e.getMessage().contains("parse"))
+      errorCode = SystemErrorCode.AI_PARSING_ERROR;
+
+    receipt.markAsFailed(errorCode);
+    return receipt;
   }
 
   public Receipt getReceiptSecurely(Long id, Long workspaceId, Long userId, boolean isAdmin) {


### PR DESCRIPTION
## 작업 요약

영수증 업로드 시 분석 완료 전 ANALYZING 상태로 선저장되도록 로직 개선

ReceiptStatus 내 상태 전이표(Transition Table) 도입으로 도메인 무결성 강화

Receipt 엔티티 내 비즈니스 메서드 분리 및 자동 승인 로직 제거

## 주요 변경 사항

ReceiptService: uploadAndProcess 내에서 save 후 OCR/AI 분석을 진행하도록 순서 변경.

ReceiptStatus: canTransitionTo() 메서드를 통해 허용되지 않은 상태 변경 시 INVALID_STATE_TRANSITION 발생.

Receipt: updateInfo에서 정보 수정 시 상태가 자동으로 APPROVED로 변하던 부작용 제거.

## 테스트 결과 (Swagger)

APPROVED 상태인 영수증을 WAITING으로 변경 시도 시 차단 확인.
<img width="1277" height="870" alt="image" src="https://github.com/user-attachments/assets/21c44b4d-5ae6-43df-b98b-f95fffc0b276" />

WAITING에서 허용되지 않은 ANALYZING으로 변경 시도 시 500 Error 확인.
<img width="1278" height="878" alt="image" src="https://github.com/user-attachments/assets/3a7e436c-8684-4d42-83dc-3128efd05d49" />

로그를 통해 분석 전 ANALYZING으로 DB에 먼저 저장되는 시점 확인.
<img width="1380" height="309" alt="image" src="https://github.com/user-attachments/assets/20f70c5e-e95e-48b9-acec-2c1df0d9930f" />
