### PR TITLE
♻️ Refactor: 상태 머신 전이 가드 강화 및 파일 검증 로직 보완

### DIFF
--- a/src/main/java/com/example/backend/domain/receipt/ReceiptStatus.java
+++ b/src/main/java/com/example/backend/domain/receipt/ReceiptStatus.java
@@ -15,16 +15,20 @@ public enum ReceiptStatus {
 
   private static final Map<ReceiptStatus, List<ReceiptStatus>> TRANSITION_TABLE =
       Map.of(
-          ANALYZING, List.of(WAITING, NEED_MANUAL, FAILED_SYSTEM),
-          WAITING, List.of(APPROVED, REJECTED, EXPIRED),
-          NEED_MANUAL, List.of(WAITING, APPROVED, REJECTED),
-          REJECTED, List.of(WAITING),
-          APPROVED, List.of());
+          ANALYZING,
+          List.of(WAITING, NEED_MANUAL, FAILED_SYSTEM),
+          WAITING,
+          List.of(APPROVED, REJECTED, EXPIRED),
+          NEED_MANUAL,
+          List.of(WAITING, APPROVED, REJECTED),
+          REJECTED,
+          List.of(WAITING),
+          FAILED_SYSTEM,
+          List.of(ANALYZING),
+          APPROVED,
+          List.of());
 
   public boolean canTransitionTo(ReceiptStatus nextStatus) {
-    if (this == nextStatus) return true;
-    List<String> allowed =
-        TRANSITION_TABLE.getOrDefault(this, List.of()).stream().map(Enum::name).toList();
     return TRANSITION_TABLE.getOrDefault(this, List.of()).contains(nextStatus);
   }
 }

--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -101,12 +101,17 @@ public class Receipt {
     this.systemErrorCode = errorCode;
   }
 
-  public void updateStatus(ReceiptStatus status, String reason) {
-    if (this.status == ReceiptStatus.APPROVED && status != ReceiptStatus.APPROVED) {
-      throw new IllegalStateException("이미 승인된 영수증의 상태를 변경할 수 없습니다.");
-    }
+  public void updateStatus(ReceiptStatus status, String reason, Long actorUserId) {
     if (!this.status.canTransitionTo(status)) {
       throw new IllegalStateException("INVALID_STATE_TRANSITION");
+    }
+
+    if (status == ReceiptStatus.APPROVED && this.userId.equals(actorUserId)) {
+      throw new IllegalStateException("SELF_APPROVAL_NOT_ALLOWED");
+    }
+
+    if (status == ReceiptStatus.REJECTED && (reason == null || reason.isBlank())) {
+      throw new IllegalStateException("REJECT_REASON_REQUIRED");
     }
 
     this.status = status;
@@ -133,14 +138,17 @@ public class Receipt {
     this.systemErrorCode = null;
   }
 
-  public void updateSystemError(SystemErrorCode errorCode) {
-    this.status = ReceiptStatus.FAILED_SYSTEM;
-    this.systemErrorCode = errorCode;
-  }
-
   public void resubmit() {
 
-    updateStatus(ReceiptStatus.WAITING, null);
+    if (this.status != ReceiptStatus.REJECTED) {
+      throw new IllegalStateException("반려된 영수증만 재제출이 가능합니다.");
+    }
+
+    if (!this.status.canTransitionTo(ReceiptStatus.WAITING)) {
+      throw new IllegalStateException("INVALID_STATE_TRANSITION");
+    }
+
+    this.status = ReceiptStatus.WAITING;
     this.rejectionReason = null;
   }
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -167,7 +167,7 @@ public class ReceiptService {
     Receipt receipt = getReceiptSecurely(id, workspaceId, userId, isAdmin);
     ReceiptStatus oldStatus = receipt.getStatus();
 
-    receipt.updateStatus(status, reason);
+    receipt.updateStatus(status, reason, userId);
     auditLogService.logStatusChange(id, userId, oldStatus, status, reason);
 
     return receipt;
@@ -240,55 +240,6 @@ public class ReceiptService {
         .collect(Collectors.toList());
   }
 
-  private Receipt parseAndSave(
-      String key,
-      String fileHash,
-      JsonNode ocrJson,
-      Long workspaceId,
-      Long userId,
-      String filePath) {
-    JsonNode textAnnotations = ocrJson.path("responses").get(0).path("textAnnotations");
-    String fullText =
-        textAnnotations.isMissingNode() ? "" : textAnnotations.get(0).path("description").asText();
-
-    JsonNode aiResult = geminiService.getParsedReceipt(fullText);
-
-    String storeName = aiResult.path("storeName").asText("알 수 없는 상호");
-    int totalAmount = aiResult.path("totalAmount").asInt(0);
-    String tradeAtStr = aiResult.path("tradeAt").asText();
-
-    ReceiptStatus finalStatus =
-        (aiResult.has("storeName") && !storeName.equals("알 수 없는 상호"))
-            ? ReceiptStatus.WAITING
-            : ReceiptStatus.NEED_MANUAL;
-
-    LocalDateTime tradeAt;
-    try {
-      tradeAt = LocalDateTime.parse(tradeAtStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-    } catch (Exception e) {
-      tradeAt = LocalDateTime.now();
-    }
-
-    Receipt tempReceiptForTagging = Receipt.builder().tradeAt(tradeAt).build();
-    List<String> derivedTags = tagService.deriveTags(tempReceiptForTagging);
-
-    return receiptRepository.save(
-        Receipt.builder()
-            .idempotencyKey(key)
-            .fileHash(fileHash)
-            .workspaceId(workspaceId)
-            .userId(userId)
-            .status(finalStatus)
-            .storeName(storeName)
-            .totalAmount(totalAmount)
-            .tradeAt(tradeAt)
-            .nightTime(derivedTags.contains("🌙 야간"))
-            .tags(derivedTags)
-            .rawText(fullText)
-            .filePath(filePath)
-            .build());
-  }
-
   private String saveFileToLocal(MultipartFile file) {
     try {
       File dir = new File(uploadDir);
@@ -307,6 +258,12 @@ public class ReceiptService {
   }
 
   private void validateFile(MultipartFile file) {
+    String contentType = file.getContentType();
+    if (contentType == null
+        || !(contentType.equals("image/jpeg") || contentType.equals("image/png"))) {
+      throw new RuntimeException("FILE_TYPE_NOT_ALLOWED");
+    }
+
     try {
       byte[] header = new byte[8];
       if (file.getInputStream().read(header) < 4) throw new RuntimeException("FILE_TOO_SMALL");


### PR DESCRIPTION
##  작업 개요

C 파트 Phase 0 작업입니다.
A(Security) 머지 전 단계로, 도메인 로직/검증/상태 기반 선작업을 완료함.

---

##  구현 항목

### 1. 초기 저장 상태 ANALYZING 강제
- 업로드 시 Receipt를 무조건 ANALYZING으로 먼저 저장
- OCR/AI 분석 완료 후에만 WAITING 또는 NEED_MANUAL로 전이
- 시스템 오류 발생 시 FAILED_SYSTEM으로 전이

### 2. 파일 검증 강화 (MIME + 매직바이트)
- 1차: file.getContentType() 기반 MIME 검증 (image/jpeg, image/png만 허용)
- 2차: 매직바이트(Magic Byte) 검증으로 확장자 위조 차단
- 실패 시 FILE_TYPE_NOT_ALLOWED 반환

### 3. updateInfo()에서 자동 APPROVED 제거
- updateInfo()는 상호명/금액/시간 값만 수정
- 승인/반려/재제출 등 상태 변경은 updateStatus() / resubmit()으로만 처리

### 4. 상태머신 전이표 (Transition Table) 적용
- 전이표 외 변경 시 INVALID_STATE_TRANSITION 예외
- 허용 전이:
  - ANALYZING → WAITING, NEED_MANUAL, FAILED_SYSTEM
  - WAITING → APPROVED, REJECTED, EXPIRED
  - NEED_MANUAL → WAITING, APPROVED, REJECTED
  - REJECTED → WAITING (재제출)
  - FAILED_SYSTEM → ANALYZING (재시도 루트, API는 Phase 1)
- 동일 상태로의 전이도 차단 (canTransitionTo에서 self 허용 제거)

### 5. 정책 예외 구현 (임시 가드)
- SELF_APPROVAL_NOT_ALLOWED: APPROVED 전이 시 본인 영수증 승인 차단
- REJECT_REASON_REQUIRED: REJECTED 전이 시 reason 공백이면 차단
- resubmit(): REJECTED 상태 전제 체크 + 상태머신 경유로 일관성 확보

---

##  Phase 1 연결 필요 사항 (PR 명시)

| 항목 | 현재 상태 | Phase 1 처리 |
|---|---|---|
| isAdmin, userId 파라미터 | 클라이언트 입력 신뢰 | JWT SecurityContext로 대체 |
| SELF_APPROVAL_NOT_ALLOWED | userId 파라미터 기반 임시 가드 | JWT actorUserId로 완전 강제 |
| ACCESS_DENIED(403) | 권한 없는 접근 시 발생 | RECEIPT_NOT_FOUND(404) 위장으로 교체 |
| 조회 스코프 | 전체 조회 후 자바 레벨 필터링 | DB 쿼리 레벨 격리로 전환 |
| FAILED_SYSTEM 재처리 API | 전이표에만 경로 추가됨 | 실제 엔드포인트 추가 |

---

##  테스트 확인 항목

- .txt 파일을 .jpg로 위장 업로드 → FILE_TYPE_NOT_ALLOWED 반환 확인
- 동일 파일 재업로드 → fileHash 중복으로 RECEIPT_DUPLICATE 처리 확인
- ANALYZING → APPROVED 직접 전이 시도 → INVALID_STATE_TRANSITION 확인
- 본인 영수증 APPROVED 시도 → SELF_APPROVAL_NOT_ALLOWED 확인
- reason 없이 REJECTED 시도 → REJECT_REASON_REQUIRED 확인
- REJECTED 상태에서 resubmit → WAITING 전이 및 rejectionReason 초기화 확인