### PR TITLE
Feat/73/영수증 선택 다운로드 구현

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -4,6 +4,7 @@ import com.example.backend.audit.AuditAction;
 import com.example.backend.audit.AuditLog;
 import com.example.backend.audit.AuditLogService;
 import com.example.backend.domain.receipt.ReceiptStatus;
+import com.example.backend.dto.ExportSelectedRequest;
 import com.example.backend.dto.ReceiptActionResponseDto;
 import com.example.backend.dto.ReceiptDetailDto;
 import com.example.backend.dto.ReceiptSummaryDto;
@@ -139,14 +140,12 @@ public class ReceiptController {
     }
   }
 
-  @SuppressWarnings("unchecked")
-  @Operation(summary = "영수증 선택 다운로드", description = "선택한 영수증만 엑셀 파일로 다운로드합니다.")
+  @Operation(summary = "영수증 선택 다운로드", description = "선택한 영수증만 엑셀 파일로 다운로드합니다. 관리자만 가능합니다.")
   @PostMapping("/export/selected")
-  public ResponseEntity<byte[]> exportSelectedToExcel(@RequestBody Map<String, Object> body) {
+  public ResponseEntity<byte[]> exportSelectedToExcel(@RequestBody ExportSelectedRequest request) {
     try {
-      Long workspaceId = Long.valueOf(body.get("workspaceId").toString());
-      List<Integer> ids = (List<Integer>) body.get("receiptIds");
-      List<Long> receiptIds = ids.stream().map(Long::valueOf).collect(Collectors.toList());
+      Long workspaceId = request.getWorkspaceId();
+      List<Long> receiptIds = request.getReceiptIds();
 
       if (!receiptService.isAdminOfWorkspace(receiptService.getCurrentUserId(), workspaceId)) {
         return ResponseEntity.status(403).build();

--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -24,7 +24,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -109,7 +111,7 @@ public class ReceiptController {
   public ResponseEntity<byte[]> exportToExcel(
       @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId) {
     try {
-      // 관리자 권한 체크
+
       if (!receiptService.isAdminOfWorkspace(receiptService.getCurrentUserId(), workspaceId)) {
         return ResponseEntity.status(403).build();
       }
@@ -133,6 +135,58 @@ public class ReceiptController {
           .body(out);
     } catch (Exception e) {
       log.error("엑셀 생성 실패", e);
+      return ResponseEntity.internalServerError().build();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Operation(summary = "영수증 선택 다운로드", description = "선택한 영수증만 엑셀 파일로 다운로드합니다.")
+  @PostMapping("/export/selected")
+  public ResponseEntity<byte[]> exportSelectedToExcel(@RequestBody Map<String, Object> body) {
+    try {
+      Long workspaceId = Long.valueOf(body.get("workspaceId").toString());
+      List<Integer> ids = (List<Integer>) body.get("receiptIds");
+      List<Long> receiptIds = ids.stream().map(Long::valueOf).collect(Collectors.toList());
+
+      if (!receiptService.isAdminOfWorkspace(receiptService.getCurrentUserId(), workspaceId)) {
+        return ResponseEntity.status(403).build();
+      }
+
+      if (receiptIds.isEmpty()) {
+        return ResponseEntity.badRequest().build();
+      }
+
+      List<Receipt> receipts =
+          receiptIds.stream()
+              .map(id -> receiptRepository.findByIdAndWorkspaceId(id, workspaceId).orElse(null))
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+
+      byte[] out = excelExportService.generateExcel(receipts, workspaceId);
+
+      auditLogService.record(
+          AuditAction.DOWNLOAD,
+          "MEMBER",
+          String.valueOf(receiptService.getCurrentUserId()),
+          workspaceId,
+          null,
+          Map.of(
+              "type",
+              "excel_export_selected",
+              "workspaceId",
+              String.valueOf(workspaceId),
+              "count",
+              String.valueOf(receipts.size())));
+
+      return ResponseEntity.ok()
+          .header(
+              HttpHeaders.CONTENT_TYPE,
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+          .header(
+              HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''receipt_selected.xlsx")
+          .body(out);
+    } catch (Exception e) {
+      log.error("선택 엑셀 생성 실패", e);
       return ResponseEntity.internalServerError().build();
     }
   }

--- a/src/main/java/com/example/backend/dto/ExportSelectedRequest.java
+++ b/src/main/java/com/example/backend/dto/ExportSelectedRequest.java
@@ -1,0 +1,12 @@
+package com.example.backend.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ExportSelectedRequest {
+  private List<Long> receiptIds;
+  private Long workspaceId;
+}

--- a/src/main/resources/static/upload.html
+++ b/src/main/resources/static/upload.html
@@ -65,6 +65,10 @@
         .modal-btns button { flex:1; padding:12px; border-radius:10px; border:none; cursor:pointer; font-weight:600; font-size:0.95rem; }
         .btn-cancel { background:#f1f5f9; color:#475569; }
         .btn-confirm { background:#1e293b; color:#fff; }
+        .checkbox-col { width:40px; text-align:center; }
+        input[type="checkbox"] { width:16px; height:16px; cursor:pointer; accent-color:var(--primary); }
+        .btn-download-selected { padding:9px 18px; border-radius:10px; border:1px solid #3b82f6; background:#eff6ff; color:#2563eb; cursor:pointer; font-size:0.85rem; font-weight:600; display:none; }
+        .btn-download-selected:hover { background:#dbeafe; }
     </style>
 </head>
 <body>
@@ -99,7 +103,8 @@
             <div class="list-header">
                 <div class="list-title">영수증 목록</div>
                 <div class="list-actions">
-                    <button class="btn-download" id="downloadBtn" style="display:none;" onclick="exportExcel()">엑셀 다운로드</button>
+                    <button class="btn-download-selected" id="selectedDownloadBtn" onclick="exportSelectedExcel()">선택 다운로드</button>
+                    <button class="btn-download" id="downloadBtn" style="display:none;" onclick="exportExcel()">전체 다운로드</button>
                     <button class="btn-upload" onclick="openModal('uploadModal')">업로드</button>
                 </div>
             </div>
@@ -109,7 +114,15 @@
                 <select class="filter-select" id="filterStatus" onchange="filterReceipts()"><option value="">상태 ▾</option><option value="WAITING">대기</option><option value="APPROVED">승인</option><option value="REJECTED">반려</option></select>
                 <select class="filter-select" id="filterSort" onchange="filterReceipts()"><option value="newest">최신순 ▾</option><option value="oldest">오래된순</option></select>
             </div>
-            <table><thead><tr><th>게시자</th><th>가맹점</th><th>금액</th><th>상태</th><th>게시일</th></tr></thead><tbody id="receiptList"></tbody></table>
+            <table>
+                <thead>
+                <tr>
+                    <th class="checkbox-col"><input type="checkbox" id="checkAll" onclick="toggleAllCheckbox(this)"></th>
+                    <th>게시자</th><th>가맹점</th><th>금액</th><th>상태</th><th>게시일</th>
+                </tr>
+                </thead>
+                <tbody id="receiptList"></tbody>
+            </table>
         </div>
     </div>
 </div>
@@ -244,13 +257,18 @@
 
     function renderReceipts() {
         const statusLabel = { WAITING: '대기', ANALYZING: '대기', NEED_MANUAL: '대기', APPROVED: '승인', REJECTED: '반려', FAILED_SYSTEM: '오류' };
-        el('receiptList').innerHTML = receiptData.map(r => `<tr onclick="location.href='/receipt-detail.html?id=${r.id}&workspaceId=${workspaceId}'">
-    <td>${escapeHtml(r.userName || '-')}</td>
-    <td><strong>${escapeHtml(r.storeName || '-')}</strong></td>
-    <td>₩${(r.totalAmount || 0).toLocaleString()}</td>
-    <td><span class="status-badge ${r.status}"><span class="dot"></span>${statusLabel[r.status] || r.status}</span></td>
-    <td style="color:#64748b;">${r.createdAt ? r.createdAt.substring(0, 10) : '-'}</td>
-  </tr>`).join('') || '<tr><td colspan="5" style="text-align:center;padding:40px;color:#94a3b8;">데이터가 없습니다.</td></tr>';
+        const isAdmin = checkIsAdmin();
+        el('receiptList').innerHTML = receiptData.map(r => `
+        <tr>
+            <td class="checkbox-col" onclick="event.stopPropagation()">
+                ${isAdmin ? `<input type="checkbox" class="receipt-checkbox" value="${r.id}" onchange="updateSelectedCount()">` : ''}
+            </td>
+            <td onclick="location.href='/receipt-detail.html?id=${r.id}&workspaceId=${workspaceId}'">${escapeHtml(r.userName || '-')}</td>
+            <td onclick="location.href='/receipt-detail.html?id=${r.id}&workspaceId=${workspaceId}'"><strong>${escapeHtml(r.storeName || '-')}</strong></td>
+            <td onclick="location.href='/receipt-detail.html?id=${r.id}&workspaceId=${workspaceId}'">₩${(r.totalAmount || 0).toLocaleString()}</td>
+            <td onclick="location.href='/receipt-detail.html?id=${r.id}&workspaceId=${workspaceId}'"><span class="status-badge ${r.status}"><span class="dot"></span>${statusLabel[r.status] || r.status}</span></td>
+            <td onclick="location.href='/receipt-detail.html?id=${r.id}&workspaceId=${workspaceId}'" style="color:#64748b;">${r.createdAt ? r.createdAt.substring(0, 10) : '-'}</td>
+        </tr>`).join('') || '<tr><td colspan="6" style="text-align:center;padding:40px;color:#94a3b8;">데이터가 없습니다.</td></tr>';
     }
 
     async function uploadReceipts() {
@@ -315,6 +333,64 @@
             alert("다운로드 오류");
         }
     }
+
+    function toggleAllCheckbox(master) {
+        document.querySelectorAll('.receipt-checkbox').forEach(cb => cb.checked = master.checked);
+        updateSelectedCount();
+    }
+
+    function updateSelectedCount() {
+        const checked = document.querySelectorAll('.receipt-checkbox:checked');
+        const btn = el('selectedDownloadBtn');
+        if (checked.length > 0) {
+            btn.style.display = 'inline-block';
+            btn.textContent = `☑️ 선택 다운로드 (${checked.length}건)`;
+        } else {
+            btn.style.display = 'none';
+        }
+        // 전체선택 체크박스 상태 동기화
+        const all = document.querySelectorAll('.receipt-checkbox');
+        if (el('checkAll')) el('checkAll').checked = all.length > 0 && checked.length === all.length;
+    }
+
+    async function exportSelectedExcel() {
+        const checked = document.querySelectorAll('.receipt-checkbox:checked');
+        if (checked.length === 0) {
+            alert("다운로드할 영수증을 선택해주세요.");
+            return;
+        }
+        const receiptIds = Array.from(checked).map(cb => parseInt(cb.value));
+        try {
+            const res = await fetch(`/api/v1/receipts/export/selected`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ receiptIds, workspaceId: parseInt(workspaceId) })
+            });
+            if (res.status === 403) {
+                alert("관리자만 다운로드할 수 있습니다.");
+                return;
+            }
+            if (!res.ok) {
+                alert("다운로드 실패");
+                return;
+            }
+            const blob = await res.blob();
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `receipt_selected_${receiptIds.length}건.xlsx`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            window.URL.revokeObjectURL(url);
+        } catch (e) {
+            alert("다운로드 오류");
+        }
+    }
+
     el('dropZone').addEventListener('click', () => el('fileInput').click());
     el('fileInput').addEventListener('change', e => {
         el('thumbs').innerHTML = Array.from(e.target.files).map(f => `<img src="${URL.createObjectURL(f)}" class="thumb">`).join('');

--- a/src/main/resources/static/upload.html
+++ b/src/main/resources/static/upload.html
@@ -117,7 +117,7 @@
             <table>
                 <thead>
                 <tr>
-                    <th class="checkbox-col"><input type="checkbox" id="checkAll" onclick="toggleAllCheckbox(this)"></th>
+                    <th class="checkbox-col"><input type="checkbox" id="checkAll" onclick="toggleAllCheckbox(this)" style="display:none;"></th>
                     <th>게시자</th><th>가맹점</th><th>금액</th><th>상태</th><th>게시일</th>
                 </tr>
                 </thead>
@@ -389,6 +389,20 @@
         } catch (e) {
             alert("다운로드 오류");
         }
+    }
+
+    function initLayout() {
+        el('headerUserName').textContent = userName || '-';
+        if (checkIsAdmin()) {
+            el('adminBtns').style.display = 'flex';
+            el('downloadBtn').style.display = 'inline-block';
+            // 관리자만 전체선택 체크박스 표시
+            el('checkAll').style.display = 'inline-block';
+        } else {
+            // 멤버는 체크박스 헤더 숨김
+            el('checkAll').style.display = 'none';
+        }
+        loadWorkspaces();
     }
 
     el('dropZone').addEventListener('click', () => el('fileInput').click());


### PR DESCRIPTION
## ❓이슈
- close #73

## 📝 Description

### 구현 배경
영수증 목록에서 원하는 영수증만 선택하여 엑셀로 다운로드하는 기능 구현
기존 전체 다운로드에서 선택 다운로드 기능을 추가하여 관리자 편의성 향상

### 구현 내용

**1. ExportSelectedRequest DTO 추가**
- receiptIds (List<Long>): 다운로드할 영수증 ID 목록
- workspaceId (Long): 워크스페이스 ID
- Swagger 요청 예시 정상 표시되도록 개선

**2. POST /api/v1/receipts/export/selected 엔드포인트 추가**
- 선택된 영수증 ID 목록으로 엑셀 생성
- 관리자 권한 체크 (비관리자 403 반환)
- 빈 목록 요청 시 400 반환
- AuditLog DOWNLOAD 기록 (type: excel_export_selected)
- 다운로드 파일명: receipt_selected.xlsx

**3. 프론트 UI 추가 (upload.html)**
- 테이블 헤더에 전체선택 체크박스 추가 (관리자만 표시)
- 각 영수증 행에 체크박스 추가 (관리자만 표시)
- 선택 시 "선택 다운로드 (N건)" 버튼 동적 표시
- 전체선택/해제 연동
- 멤버는 체크박스 미표시

### 요청 형식
```json
POST /api/v1/receipts/export/selected
{
  "receiptIds": [1, 2, 3],
  "workspaceId": 1
}
```

### 테스트 결과

**관리자 - 선택 다운로드 성공 (200)**
<img width="517" height="477" alt="image" src="https://github.com/user-attachments/assets/5ebc1230-5d22-4d94-a963-b6a0a1e5ae13" />

**멤버 - 접근 시 403**
<img width="421" height="434" alt="image" src="https://github.com/user-attachments/assets/128d4781-e0c1-4e2e-8302-992809578ea5" />

**빈 목록 요청 시 400**
<img width="497" height="463" alt="image" src="https://github.com/user-attachments/assets/19b5ac8e-1427-4de1-9ac6-aaa01f8f4a99" />

**AuditLog DOWNLOAD 기록 확인**
<img width="1475" height="171" alt="image" src="https://github.com/user-attachments/assets/21f589e5-9c7b-4a23-8d8a-07b9b93b5083" />

## 🌀 PR Type
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] 관리자 선택 다운로드 성공 확인
- [x] 멤버 접근 시 403 확인
- [x] 빈 목록 요청 시 400 확인
- [x] 체크박스 전체선택/해제 동작 확인
- [x] 선택 건수 버튼 동적 표시 확인
- [x] 멤버 로그인 시 체크박스 미표시 확인
- [x] AuditLog DOWNLOAD 기록 확인
- [x] CI 테스트 통과